### PR TITLE
fix MDTableIndex RID off-by-one bug

### DIFF
--- a/src/dnfile/base.py
+++ b/src/dnfile/base.py
@@ -451,7 +451,7 @@ class MDTableIndex(object):
             if isinstance(t, self._table_class):
                 self.table = t
                 # TODO error checking
-                self.row = t.rows[self.row_index]
+                self.row = t.rows[self.row_index - 1]
 
 
 class CodedIndex(MDTableIndex):
@@ -468,4 +468,4 @@ class CodedIndex(MDTableIndex):
                     # TODO error/warn
                     self.row = None
                     return
-                self.row = t.rows[self.row_index]
+                self.row = t.rows[self.row_index - 1]


### PR DESCRIPTION
`ClrMetaDataTable.rows` is zero-based so we need to subtract one from the RID when setting `MDTableIndex.row`.