### PR TITLE
CodedIndex: fix off-by-one during row bounds check

### DIFF
--- a/src/dnfile/base.py
+++ b/src/dnfile/base.py
@@ -464,7 +464,7 @@ class CodedIndex(MDTableIndex):
         for t in tables_list:
             if t.name == table_name:
                 self.table = t
-                if self.row_index > t.num_rows - 1:
+                if self.row_index > t.num_rows:
                     # TODO error/warn
                     self.row = None
                     return


### PR DESCRIPTION
ClrMetaDataTable.row_index is one-indexed so the range check should not decrement the `num_rows` limit.