### PR TITLE
Add basic CI configuration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,6 @@
 name: lint
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout dnfile
+      uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - name: Install dependencies
+      run: pip install -e .
+    # doesn't do anything yet.


### PR DESCRIPTION
Adds a skeleton configuration for CI via Github Actions. Right now, it just demonstrates that the package can be installed. I'd recommend other steps, just a style, type checking, formatting, and testing, but I'll propose those in separate PRs so you can choose what you'd like.

We use GH Actions quite heavily with capa; our configuration is [here](https://github.com/mandiant/capa/tree/master/.github/workflows) if you'd like to review.