### PR TITLE
lint code with isort

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,5 +13,6 @@ jobs:
       with:
         python-version: "3.8"
     - name: Install dependencies
-      run: pip install -e .
-    # doesn't do anything yet.
+      run: pip install -e .[test]
+    - name: Lint with isort
+      run: isort --profile black --length-sort --line-width 120 -c .

--- a/examples/dnstrings.py
+++ b/examples/dnstrings.py
@@ -3,6 +3,7 @@
 # Iterate UserStrings and display one per line.
 
 import sys
+
 import dnfile
 
 

--- a/examples/typeref-list.py
+++ b/examples/typeref-list.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 import sys
-import dnfile
 
+import dnfile
 
 for fname in sys.argv[1:]:
     # load .NET executable

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup_requirements = [
 
 test_requirements = [
     "pytest>=3",
+    "isort==5.2.0",
 ]
 
 setup(
@@ -47,6 +48,7 @@ setup(
     setup_requires=setup_requirements,
     test_suite="tests",
     tests_require=test_requirements,
+    extras_require={'test': test_requirements},
     url="https://github.com/malwarefrank/dnfile",
     version="0.8.0",
     zip_safe=False,

--- a/src/dnfile/__init__.py
+++ b/src/dnfile/__init__.py
@@ -16,22 +16,14 @@ __author__ = """MalwareFrank"""
 __version__ = "0.8.0"
 
 
-import struct as _struct
 import copy as _copymod
-from typing import List, Dict
+import struct as _struct
+from typing import Dict, List
 
-from pefile import (
-    MAX_SYMBOL_EXPORT_COUNT,
-    PEFormatError,
-    Structure,
-    DataContainer,
-    PE as _PE,
-    DIRECTORY_ENTRY,
-    Dump,
-)
+from pefile import PE as _PE
+from pefile import DIRECTORY_ENTRY, MAX_SYMBOL_EXPORT_COUNT, Dump, Structure, DataContainer, PEFormatError
 
 from . import enums, errors, stream
-
 
 CLR_METADATA_SIGNATURE = 0x424A5342
 

--- a/src/dnfile/base.py
+++ b/src/dnfile/base.py
@@ -7,9 +7,9 @@ Copyright (c) 2020-2021 MalwareFrank
 
 
 import abc
-import collections
 import struct as _struct
-from typing import Tuple, List, Dict, Optional, Type
+import collections
+from typing import Dict, List, Type, Tuple, Optional
 
 from pefile import Structure
 

--- a/src/dnfile/codedindex.py
+++ b/src/dnfile/codedindex.py
@@ -12,10 +12,9 @@ REFERENCES
 Copyright (c) 2020-2021 MalwareFrank
 """
 
-from typing import Tuple, List
+from typing import List, Tuple
 
 from .base import CodedIndex
-
 
 # TODO add table_numbers to all
 

--- a/src/dnfile/enums.py
+++ b/src/dnfile/enums.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import enum as _enum
-from typing import Iterable, Dict
-
+from typing import Dict, Iterable
 
 ########
 # Most developers may just use the Clr* classes to automatically parse the

--- a/src/dnfile/mdtable.py
+++ b/src/dnfile/mdtable.py
@@ -15,9 +15,8 @@ Copyright (c) 2020-2021 MalwareFrank
 
 from typing import List, Type
 
-from .base import MDTableRow, ClrMetaDataTable, RowStruct, ClrHeap
-from . import utils, codedindex, enums
-
+from . import enums, utils, codedindex
+from .base import ClrHeap, RowStruct, MDTableRow, ClrMetaDataTable
 
 #### Module Table
 #

--- a/src/dnfile/stream.py
+++ b/src/dnfile/stream.py
@@ -12,15 +12,12 @@ Copyright (c) 2020-2021 MalwareFrank
 
 import copy as _copymod
 import struct as _struct
+from typing import Dict, List, Tuple
 from binascii import hexlify as _hexlify
 
-from pefile import Structure
-from pefile import DataContainer
-from pefile import MAX_STRING_LENGTH
+from pefile import MAX_STRING_LENGTH, Structure, DataContainer
 
-from typing import Dict, List, Tuple
-
-from . import errors, mdtable, base
+from . import base, errors, mdtable
 from .utils import read_compressed_int
 
 

--- a/src/dnfile/utils.py
+++ b/src/dnfile/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import functools as _functools
 import copy as _copymod
+import functools as _functools
 
 from pefile import Structure
 


### PR DESCRIPTION
(this depends on #4 for GH Actions configuration. please review and merge/reject that first).

Like #6, this introduces a code linter that you can optionally decide to use for dnfile. If you like it, then this PR configures GH Actions to check for violations during CI. 

isort orders imports consistently. I've configured it here to do two things:
  1. split imports by groups: stdlib, dependencies, project locals
  2. order by line length

The idea here is to enforce a basic set of consistency. If you like it, please merge! If not, no worries!

Note: you can use the command `python -m isort --profile black --length-sort --line-width 120 .` to automatically apply all fixes recommended by isort. This is what I do with all my projects before pushing/creating a PR.