### PR TITLE
add basic tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/data"]
+	path = tests/data
+	url = https://github.com/malwarefrank/dnfile-testfiles.git

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+CD = Path(__file__).parent
+DATA = CD / "data"
+
+def get_data_path_by_name(name):
+    if name == "hello-world.exe":
+        return DATA / "hello-world" / "hello-world.exe"
+
+    raise ValueError("unknown test file")

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,0 +1,44 @@
+import dnfile
+
+import fixtures
+
+
+def test_metadata():
+    path = fixtures.get_data_path_by_name("hello-world.exe")
+
+    dn = dnfile.dnPE(path)
+
+    assert hasattr(dn, "net")
+
+    dn.net.metadata.struct.Signature == 0x424A5342
+    dn.net.metadata.struct.MajorVersion == 1
+    dn.net.metadata.struct.MinorVersion == 1
+    dn.net.metadata.struct.Version == "v4.0.30319"
+    dn.net.metadata.struct.Flags == 0x0
+    dn.net.metadata.struct.NumberOfStreams == 5
+
+
+def test_streams():
+    path = fixtures.get_data_path_by_name("hello-world.exe")
+
+    dn = dnfile.dnPE(path)
+
+    assert b"#~" in dn.net.metadata.streams
+    assert hasattr(dn.net, "metadata")
+
+    # strings used by #~
+    assert b"#Strings" in dn.net.metadata.streams
+    assert hasattr(dn.net, "strings")
+
+    # "user strings"
+    assert b"#US" in dn.net.metadata.streams
+    # not sure where these are accessible yet
+
+    assert b"#GUID" in dn.net.metadata.streams
+    assert hasattr(dn.net, "guids")
+
+    assert b"#Blob" in dn.net.metadata.streams
+    assert hasattr(dn.net, "blobs")
+
+    assert b"#Foo" not in dn.net.metadata.streams
+    assert not hasattr(dn.net, "foo")


### PR DESCRIPTION
relies on https://github.com/malwarefrank/dnfile-testfiles/pull/1 being merged (and then will need to update the submodule here). 

Adds a couple tests demonstrating metadata parsing and stream parsing.