### PR TITLE
mdtable: implement TypeDefRow.Extends mapping

### DIFF
--- a/src/dnfile/mdtable.py
+++ b/src/dnfile/mdtable.py
@@ -153,6 +153,9 @@ class TypeDefRow(MDTableRow):
     _struct_flags = {
         "Flags": ("Flags", enums.ClrTypeAttr),
     }
+    _struct_codedindexes = {
+        "Extends_CodedIndex": ("Extends", codedindex.TypeDefOrRef),
+    }
 
     def _init_format(self):
         extends_size = self._clr_coded_index_struct_size(


### PR DESCRIPTION
seemed to be a missing property mapping