### PR TITLE
dndump: better render invalid strings

### DIFF
--- a/examples/dndump.py
+++ b/examples/dndump.py
@@ -28,10 +28,7 @@ def is_printable(s: str) -> bool:
     this is just a heuristic to detect invalid strings.
     it won't work perfectly, but is probably good enough for rendering here.
     """
-    try:
-        return all(map(lambda b: b in string.printable, s))
-    except UnicodeEncodeError:
-        return False
+    return all(map(lambda b: b in string.printable, s))
 
 
 class Formatter:

--- a/examples/dndump.py
+++ b/examples/dndump.py
@@ -6,6 +6,7 @@ relies on tabulate, which you can install like: `pip install tabulate`
 '''
 import io
 import sys
+import string
 import logging
 import argparse
 import binascii
@@ -18,6 +19,19 @@ import dnfile.base
 import dnfile.enums
 
 logger = logging.getLogger(__name__)
+
+
+def is_printable(s: str) -> bool:
+    """
+    does the given string look like a very simple string?
+
+    this is just a heuristic to detect invalid strings.
+    it won't work perfectly, but is probably good enough for rendering here.
+    """
+    try:
+        return all(map(lambda b: b in string.printable, s))
+    except UnicodeEncodeError:
+        return False
 
 
 class Formatter:
@@ -45,7 +59,7 @@ class Formatter:
         return self._s.getvalue()
 
     HEX_BY_BYTE = ["%02x" % b for b in range(0x100)]
-    ASCII_BY_BYTE = [(chr(b) if (b >= 0x20 and b <= 0x7F) else ".") for b in range(0x100)]
+    ASCII_BY_BYTE = [(chr(b) if (b >= 0x20 and b <= 0x7E) else ".") for b in range(0x100)]
 
     def hexdump(self, buf: bytes, address=0):
         for chunk_offset in range(0, len(buf), 0x10):
@@ -104,8 +118,10 @@ def render_pefile_struct(ostream: Formatter, struct):
         for keys in struct.__keys__:
             key = keys[0]
             value = obj[key]["Value"]
+
             if isinstance(value, int):
                 value = hex(value)
+
             rows.append(("%s:" % (key), value))
         ostream.rows(rows)
 
@@ -212,6 +228,11 @@ def render_pe(ostream: Formatter, dn):
                                     if len(v) == 0:
                                         value = "(empty)"
                                     else:
+                                        if not is_printable(v):
+                                            # doesn't look like a simple string,
+                                            # so render it like bytes.
+                                            # this came from utf-8, so use that physical representation.
+                                            v = "(invalid){!r}".format(v.encode("utf-8"))
                                         value = v
                                 elif isinstance(v, int):
                                     value = "0x%x" % (v)


### PR DESCRIPTION
in obfuscated sample 0033ca037e0496c5c33e3dc19714fb3e, some strings, like a Module name, are invalid, and get rendered with escape sequences. this PR introduces a heuristic to identify "probably bad" strings and render them with a caveat.

from CFF explorer:
![image](https://user-images.githubusercontent.com/156560/146270663-a48a86f7-3161-4489-a6dc-00a3ae7ff494.png)

dndump (after PR):
![image](https://user-images.githubusercontent.com/156560/146270849-8d209640-c4ac-4176-892a-b8504825b733.png)

