### PR TITLE
add type annotation stuff for PEP 561 compatible packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     name="dnfile",
     packages=find_packages(where="src", include=["dnfile", "dnfile.*"]),
     package_dir={"": "src"},
+    package_data={"dnfile": ["py.typed"]},
     setup_requires=setup_requirements,
     test_suite="tests",
     tests_require=test_requirements,


### PR DESCRIPTION
enables mypy to be able to recognized types already provided by this library. I used the reference here: https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages