### PR TITLE
comprehensively set flags and enums

### DIFF
--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -150,3 +150,21 @@ def test_ignore_NumberOfRvaAndSizes():
     dn = dnfile.dnPE(path)
     assert hasattr(dn, "net") and dn.net is not None
     assert hasattr(dn.net, "metadata") and dn.net.metadata is not None
+
+
+def test_flags():
+    path = fixtures.get_data_path_by_name("hello-world.exe")
+
+    dn = dnfile.dnPE(path)
+    assert dn.net is not None
+
+    # class HelloWorld
+    cls = dn.net.mdtables.TypeDef.get_with_row_index(2)
+
+    # these are enums from CorTypeSemantics
+    assert cls.Flags.tdClass is True
+    assert cls.Flags.tdInterface is False
+
+    # these are flags from CorTypeAttrFlags
+    assert cls.Flags.tdBeforeFieldInit is True
+    assert cls.Flags.tdAbstract is False


### PR DESCRIPTION
building on an idea from #20, use `setattr(..., False)` to provide the value `False` to unset flags and non-present enum variants. this means that the flag/enum properties are always present (and IDEs can autocomplete) and should be checked like:

```py
if cls.Flags.tdClass: ...
```

versus the old ways:

```
if hasattr(cls.Flags, "tdClass") and cls.Flags.tdClass: ...
if getattr(cls.Flags, "tdClass", False): ....
```

the new tests demonstrate this nicely:

![image](https://user-images.githubusercontent.com/156560/146608044-fac67fe0-bcd9-4fc0-ab63-7c3a95c2d37e.png)

i can think of no downsides, except the tiny performance overhead of setting more props on these instances.