### PR TITLE
default values, remove duplicate warnings, and more inline comments

### DIFF
--- a/src/dnfile/base.py
+++ b/src/dnfile/base.py
@@ -346,7 +346,7 @@ class MDTableRow(abc.ABC):
                     if t.name == table_name:
                         table = t
 
-                run = []
+                run: List[MDTableIndex] = []
                 # always define attribute, even if failed to parse
                 setattr(self, attr_name, run)
 

--- a/src/dnfile/base.py
+++ b/src/dnfile/base.py
@@ -216,15 +216,20 @@ class MDTableRow(abc.ABC):
         """
         Parse the row data and set object attributes.  Should only be called after all rows of all tables
         have been initialized, i.e. parse_rows() has been called on each table in the tables list.
+
+            next_row    the next row in the table, used for row lists (e.g. FieldList, MethodList)
         """
         # if there are any fields to copy as-is
         if hasattr(self.__class__, "_struct_asis"):
             for struct_name, attr_name in self.__class__._struct_asis.items():
+                # always define attribute, even if failed to parse
                 setattr(self, attr_name, getattr(self.struct, struct_name, None))
 
         # if strings
         if hasattr(self.__class__, "_struct_strings"):
             for struct_name, attr_name in self.__class__._struct_strings.items():
+                # always define attribute, even if failed to parse
+                setattr(self, attr_name, None)
                 if self._strings is None:
                     logger.warning("failed to fetch string: no strings table")
                     continue
@@ -243,6 +248,8 @@ class MDTableRow(abc.ABC):
         # if guids
         if hasattr(self.__class__, "_struct_guids"):
             for struct_name, attr_name in self.__class__._struct_guids.items():
+                # always define attribute, even if failed to parse
+                setattr(self, attr_name, None)
                 if self._guids is None:
                     logger.warning("failed to fetch guid: no guid table")
                     continue
@@ -256,6 +263,8 @@ class MDTableRow(abc.ABC):
         # if blobs
         if hasattr(self.__class__, "_struct_blobs"):
             for struct_name, attr_name in self.__class__._struct_blobs.items():
+                # always define attribute, even if failed to parse
+                setattr(self, attr_name, None)
                 if self._blobs is None:
                     logger.warning("failed to fetch blob: no blob table")
                     continue
@@ -271,6 +280,8 @@ class MDTableRow(abc.ABC):
                 attr_name,
                 attr_class,
             ) in self.__class__._struct_codedindexes.items():
+                # always define attribute, even if failed to parse
+                setattr(self, attr_name, None)
                 try:
                     o = attr_class(getattr(self.struct, struct_name, None), tables)
                     setattr(self, attr_name, o)
@@ -280,6 +291,8 @@ class MDTableRow(abc.ABC):
         # if flags
         if hasattr(self.__class__, "_struct_flags"):
             for struct_name, (attr_name, flag_class) in self.__class__._struct_flags.items():
+                # always define attribute, even if failed to parse
+                setattr(self, attr_name, None)
                 # Set the flags according to the Flags member
                 v = getattr(self.struct, struct_name, None)
                 if v is None:
@@ -294,6 +307,8 @@ class MDTableRow(abc.ABC):
         # if enums
         if hasattr(self.__class__, "_struct_enums"):
             for struct_name, (attr_name, enum_class) in self.__class__._struct_enums.items():
+                # always define attribute, even if failed to parse
+                setattr(self, attr_name, None)
                 # Set the value according to the Enum member
                 v = getattr(self.struct, struct_name, None)
                 if v is None:
@@ -308,6 +323,9 @@ class MDTableRow(abc.ABC):
         # if indexes
         if hasattr(self.__class__, "_struct_indexes") and tables:
             for struct_name, (attr_name, table_name) in self.__class__._struct_indexes.items():
+                # always define attribute, even if failed to parse
+                setattr(self, attr_name, None)
+
                 table = None
                 for t in tables:
                     if t.name == table_name:
@@ -322,19 +340,21 @@ class MDTableRow(abc.ABC):
         # if lists
         if hasattr(self.__class__, "_struct_lists") and tables:
             for struct_name, (attr_name, table_name) in self.__class__._struct_lists.items():
+
                 table = None
                 for t in tables:
                     if t.name == table_name:
                         table = t
 
+                run = []
+                # always define attribute, even if failed to parse
+                setattr(self, attr_name, run)
+
                 if not table:
                     # target table is not present,
                     # such as is there is no Field table in hello-world.exe,
                     # so the references below must, by defintion, be empty.
-                    setattr(self, attr_name, [])
                     continue
-
-                run = []
 
                 run_start_index = getattr(self.struct, struct_name, None)
                 if run_start_index is not None:

--- a/src/dnfile/mdtable.py
+++ b/src/dnfile/mdtable.py
@@ -54,11 +54,11 @@ class ModuleRow(MDTableRow):
     #
     # these are type hints for properties dynamically set during structure parsing.
     #
-    Generation: int
-    Name: str
-    Mvid: str
-    EncId: str
-    EncBaseId: str
+    Generation: Optional[int]
+    Name: Optional[str]
+    Mvid: Optional[str]
+    EncId: Optional[str]
+    EncBaseId: Optional[str]
 
     #
     # raw structure definition

--- a/src/dnfile/stream.py
+++ b/src/dnfile/stream.py
@@ -235,7 +235,7 @@ class MetaDataTables(base.ClrStream):
         ),
     )
 
-    header: MDTablesStruct
+    header: Optional[MDTablesStruct]
     tables: Dict[Union[str, int], base.ClrMetaDataTable]
     tables_list: List[base.ClrMetaDataTable]
     strings_offset_size: int
@@ -283,6 +283,15 @@ class MetaDataTables(base.ClrStream):
     GenericParamConstraint: mdtable.GenericParamConstraint
     Unused:                 mdtable.Unused
 
+    def __init__(self, metadata_rva: int, stream_struct: base.StreamStruct, stream_data: bytes):
+        super().__init__(metadata_rva, stream_struct, stream_data)
+        self.header = None
+        self.tables = dict()
+        self.tables_list = list()
+        strings_offset_size = 0
+        guids_offset_size = 0
+        blobs_offset_size = 0
+
     def parse(self, streams: List[base.ClrStream]):
         """
         this may raise an exception if the data cannot be parsed correctly.
@@ -301,9 +310,7 @@ class MetaDataTables(base.ClrStream):
         # and then raise the first deferred exception captured here.
         deferred_exceptions = list()
 
-        self.tables = dict()
-        self.tables_list = list()
-        header_len = Structure(self._format).sizeof()
+        header_len = Structure(self.__class__._format).sizeof()
         if not self.__data__ or len(self.__data__) < header_len:
             logger.warning("unable to read .NET metadata tables")
             raise errors.dnFormatError("Unable to read .NET metadata tables")


### PR DESCRIPTION
Closes #20

Predictable attribute presence with default None or empty values:
- dnPE.net is None
- the follow dnPE.net attributes are set to None by default
  - metadata
  - strings
  - user_strings
  - guids
  - blobs
  - mdtables
  - Flags
- MDTableRow objects - every attribute is initialized to None, except Lists which are initialized to empty
- MetadataTables stream object
  - header is None
  - tables is empty dict()
  - tables_list is empty list()
  - *_offset_size = 0