### PR TITLE
fix AttributeError: 'Module' object has no attribute 'rva'

### DIFF
--- a/src/dnfile/__init__.py
+++ b/src/dnfile/__init__.py
@@ -102,7 +102,7 @@ class dnPE(_PE):
                     if hasattr(s, "tables_list") and s.tables_list:
                         for t in s.tables_list:
                             for label, value in (
-                                ("RVA", hex(t.rva)),
+                                ("RVA", hex(t.rva if hasattr(t, "rva") else 0)),
                                 ("TableName", t.name),
                                 ("TableNumber", t.number),
                                 ("IsSorted", t.is_sorted),


### PR DESCRIPTION
test file 8af6e0d6bbc17cfd8635a1061b421c6a3bdc2ba54704f1b28221a7f695972113
but in gneral i think this field is broken as it always set to 0 aka `else` block. but at least after this it print info nicely 

```
>>> dn.print_info()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/pefile.py", line 6020, in print_info
    print(self.dump_info(encoding=encoding))
  File "/usr/local/lib/python3.9/site-packages/dnfile/__init__.py", line 105, in dump_info
    ("RVA", hex(t.rva)),
AttributeError: 'Module' object has no attribute 'rva'
```