### PR TITLE
fix off-by-one error w/ parsing table lists

### DIFF
--- a/src/dnfile/base.py
+++ b/src/dnfile/base.py
@@ -367,7 +367,8 @@ class MDTableRow(abc.ABC):
                         next_row_reference = getattr(next_row.struct, struct_name, None)
                         run_end_index = max_row
                         if next_row_reference is not None:
-                            run_end_index = min(next_row_reference, max_row)
+                            # row end index is inclusive so row end index must equal next row index minus 1, if less than max row
+                            run_end_index = min(next_row_reference - 1, max_row)
 
                     else:
                         # then we read from the target table,
@@ -379,7 +380,7 @@ class MDTableRow(abc.ABC):
                     # start == end and end == max_row.
                     # otherwise, if start == end, then run is empty.
                     if (run_start_index != run_end_index) or (run_end_index == max_row):
-                        # row indexes are 1-indexed, so our range goes to end+1
+                        # row indexes are inclusive, so our range goes to end+1
                         for row_index in range(run_start_index, run_end_index + 1):
                             run.append(MDTableIndex(table, row_index))
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -7,5 +7,7 @@ DATA = CD / "data"
 def get_data_path_by_name(name):
     if name == "hello-world.exe":
         return DATA / "hello-world" / "hello-world.exe"
+    elif name == "ModuleCode_x86.exe":
+        return DATA / "mixed-mode" / "ModuleCode" / "bin" / "ModuleCode_x86.exe"
 
     raise ValueError("unknown test file")

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -185,26 +185,23 @@ def test_typedef_extends():
 
 
 def test_typedef_members():
-    path = fixtures.get_data_path_by_name("hello-world.exe")
+    path = fixtures.get_data_path_by_name("ModuleCode_x86.exe")
 
     dn = dnfile.dnPE(path)
     assert dn.net is not None
 
     typedefs = dn.net.mdtables.TypeDef
     assert typedefs[0].TypeName == "<Module>"
-    assert typedefs[1].TypeName == "HelloWorld"
+    assert typedefs[5].TypeName == "ModuleLoadException"
 
-    # neither class has fields
-    assert len(typedefs[0].FieldList) == 0
-    assert len(typedefs[1].FieldList) == 0
+    assert len(typedefs[0].FieldList) == 52
+    assert len(typedefs[5].FieldList) == 0
 
-    # <Module> has no methods
-    assert len(typedefs[0].MethodList) == 0
-    # HelloWorld has two methods: Main and .ctor
-    assert len(typedefs[1].MethodList) == 2
+    assert len(typedefs[0].MethodList) == 76
+    assert len(typedefs[5].MethodList) == 3
 
-    assert typedefs[1].MethodList[0].row.Name == "Main"
-    assert typedefs[1].MethodList[1].row.Name == ".ctor"
+    assert typedefs[0].MethodList[0].row.Name == "rc4_init"
+    assert typedefs[5].MethodList[0].row.Name == ".ctor"
 
 
 def test_method_params():


### PR DESCRIPTION
fixes bug that introduced duplicate entries in table lists and updates `TypeDef` member tests to use a binary with sequential list runs.