### PR TITLE
Add optional lazy loading for .NET metadata tables

### DIFF
--- a/src/dnfile/__init__.py
+++ b/src/dnfile/__init__.py
@@ -525,9 +525,15 @@ class ClrData(DataContainer):
         if not lazy_load:
             self._init_resources(pe)
         else:
+            # store the dnPE reference for lazy-loading
             setattr(self, "_pe", pe)
 
     def _init_resources(self, pe):
+        """Parse and initialize assembly resources.
+
+        This is separate from `ClrData.__init__` to allow for mdtable lazy-loading since
+        parsing `ManifestResourceRow.Implementation` requires all tables to be loaded.
+        """
         self._resources = []
         # parse the resources
         if self.struct.ResourcesRva > 0 and self.mdtables and self.mdtables.ManifestResource and self.mdtables.ManifestResource.num_rows > 0:

--- a/src/dnfile/__init__.py
+++ b/src/dnfile/__init__.py
@@ -426,10 +426,11 @@ class ClrData(DataContainer):
     Flags: Optional[enums.ClrHeaderFlags]
 
     _resources: Optional[List[base.ClrResource]]
+
     @property
     def resources(self) -> List[base.ClrResource]:
         if self._resources is None:
-            self._init_resources(self._pe)
+            self._init_resources(getattr(self, "_pe"))
             assert self._resources is not None
         return self._resources
 

--- a/src/dnfile/base.py
+++ b/src/dnfile/base.py
@@ -161,8 +161,6 @@ class MDTableRow(abc.ABC):
     _struct_enums: Dict[str, Tuple[str, Type[enum.IntEnum]]]         # also enum.IntEnum subclassA
     _struct_lists: Dict[str, Tuple[str, str]]                        # also Metadata table name
 
-    _loaded = LoadState.Unloaded
-
     def __init__(
         self,
         tables_rowcounts: List[Optional[int]],
@@ -184,6 +182,8 @@ class MDTableRow(abc.ABC):
         tables_rowcounts is indexed by table number.  The value is the row count, if it exists, or None.
         """
         assert hasattr(self.__class__, "_struct_class")
+
+        self._loaded = LoadState.Unloaded
 
         self._tables_rowcnt = tables_rowcounts
         self._strings: Optional["stream.StringsHeap"] = strings_heap
@@ -613,8 +613,6 @@ class ClrMetaDataTable(Generic[RowType]):
     name: str
     _row_class: Type[RowType]
 
-    _loaded = LoadState.Unloaded
-
     def __init__(
         self,
         tables_rowcounts: List[Optional[int]],
@@ -639,6 +637,8 @@ class ClrMetaDataTable(Generic[RowType]):
         assert hasattr(self, "number")
         assert hasattr(self, "name")
         assert hasattr(self, "_row_class")
+
+        self._loaded = LoadState.Unloaded
 
         # default value
         self.rva: int = 0

--- a/src/dnfile/base.py
+++ b/src/dnfile/base.py
@@ -6,9 +6,9 @@ Copyright (c) 2020-2022 MalwareFrank
 """
 import abc
 import enum
-import functools as _functools
 import struct as _struct
 import logging
+import functools as _functools
 from typing import TYPE_CHECKING, Dict, List, Type, Tuple, Union, Generic, TypeVar, Optional, Sequence
 
 from pefile import Structure
@@ -233,7 +233,7 @@ class MDTableRow(abc.ABC):
     )
     # cannot be fully parsed without all tables being initialized
     CLASS_ATTRS_TABLES = (
-        "_struct_codedindexes", "_struct_indexes","_struct_lists"
+        "_struct_codedindexes", "_struct_indexes", "_struct_lists"
     )
 
     def setup_lazy_load(self, full_loader):
@@ -268,7 +268,6 @@ class MDTableRow(abc.ABC):
         self._parse_struct_indexes(tables, next_row)
         self._parse_struct_lists(tables, next_row)
         self._loaded = LoadState.Loaded
-
 
     def _parse_struct_asis(self):
         # if there are any fields to copy as-is
@@ -484,7 +483,7 @@ class MDTableRow(abc.ABC):
             return "I"
 
 
-@_functools.cache
+@_functools.lru_cache(None)
 def _row_class_struct_attrs(cls):
     attrs = {
         attr[0] if isinstance(attr, tuple) else attr: struct
@@ -614,7 +613,7 @@ class ClrMetaDataTable(Generic[RowType]):
     name: str
     _row_class: Type[RowType]
 
-    _loaded=LoadState.Unloaded
+    _loaded = LoadState.Unloaded
 
     def __init__(
         self,
@@ -728,7 +727,7 @@ class ClrMetaDataTable(Generic[RowType]):
         except errors.dnFormatError:
             # this may occur when the offset to a stream is too large.
             # this probably means invalid data.
-            logger.warning("failed to construct %s row %d",self.name, idx)
+            logger.warning("failed to construct %s row %d", self.name, idx)
             assert isinstance(self.rows, _LazyList)
             self.rows.truncate(idx)
             return

--- a/src/dnfile/base.py
+++ b/src/dnfile/base.py
@@ -9,6 +9,7 @@ import enum
 import struct as _struct
 import logging
 import functools as _functools
+import itertools as _itertools
 from typing import TYPE_CHECKING, Dict, List, Type, Tuple, Union, Generic, TypeVar, Optional, Sequence
 
 from pefile import Structure
@@ -785,7 +786,12 @@ class ClrMetaDataTable(Generic[RowType]):
             return row
 
         if isinstance(key, slice):
-            return [self._lazy_parse_row(row, i) for row, i in zip(row, range(key.start, key.stop, key.step))]
+            # normally not knowing the length of the list a slice was taken from
+            # would be an issue, but we can just keep going until `row` is exhausted.
+            return [
+                self._lazy_parse_row(row, i)
+                for row, i in zip(row, _itertools.count(key.start or 0, key.step or 1))
+            ]
 
         return self._lazy_parse_row(row, key)
 

--- a/src/dnfile/mdtable.py
+++ b/src/dnfile/mdtable.py
@@ -2155,6 +2155,7 @@ class ClrMetaDataTableFactory(object):
         strings_heap: Optional["stream.StringsHeap"],
         guid_heap: Optional["stream.GuidHeap"],
         blob_heap: Optional["stream.BlobHeap"],
+        lazy_load=False
     ) -> ClrMetaDataTable:
         if number not in cls._table_number_map:
             raise errors.dnFormatError("invalid table index")
@@ -2168,5 +2169,6 @@ class ClrMetaDataTableFactory(object):
             strings_heap,
             guid_heap,
             blob_heap,
+            lazy_load,
         )
         return table

--- a/src/dnfile/stream.py
+++ b/src/dnfile/stream.py
@@ -459,12 +459,15 @@ class MetaDataTables(base.ClrStream):
             self._loaded = False
 
             def full_loader():
+                # Called if a property is accessed that requires data from other tables.
+                # This will be called multiple times while parsing tables.
                 if not self._loaded:
+                    self._loaded = True
                     # parse_rows is redundant for lazy loading
                     for table in self.tables_list:
                         table.parse(self.tables_list)
-                self._loaded = True
 
+            # Setup lazy loading for all tables
             for table in self.tables_list:
                 if table.row_size > 0 and table.num_rows > 0:
                     table_data = self.get_data_at_rva(

--- a/src/dnfile/stream.py
+++ b/src/dnfile/stream.py
@@ -455,9 +455,9 @@ class MetaDataTables(base.ClrStream):
                 if table.name:
                     setattr(self, table.name, table)
 
-
         if lazy_load:
             self._loaded = False
+
             def full_loader():
                 if not self._loaded:
                     # parse_rows is redundant for lazy loading

--- a/src/dnfile/utils.py
+++ b/src/dnfile/utils.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from collections import deque
 import copy as _copymod
 import logging
 import functools as _functools
-from typing import Tuple, Optional, TypeVar, List
+from typing import List, Tuple, TypeVar, Optional, cast
+from collections import deque
 
 logger = logging.getLogger(__name__)
 
@@ -85,12 +85,14 @@ def num_bytes_to_struct_char(n: int) -> Optional[str]:
         logger.warning("invalid format specifier: %d", n)
         return None
 
+
 _ListType = TypeVar("_ListType")
 
+
 class LazyList(List[_ListType]):
-    def __init__(self, eval_func, initial_size: int ):
+    def __init__(self, eval_func, initial_size: int):
         self.eval_func = eval_func
-        super().__init__([None] * initial_size)
+        super().__init__(cast(List[_ListType], [None] * initial_size))
 
     def __getitem__(self, __key):
         __value = super().__getitem__(__key)
@@ -100,13 +102,13 @@ class LazyList(List[_ListType]):
         return new
 
     def __iter__(self):
-        i=0
+        i = 0
         for v in super().__iter__():
             new = self.eval_func(i, v)
             if v != new:
                 super().__setitem__(i, new)
             yield new
-            i+=1
+            i += 1
 
     def eval_all(self):
         deque(self, maxlen=0)

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -17,20 +17,32 @@ def test_lazy_loading():
     assert dn.net.mdtables.MemberRef
     assert isinstance(dn.net.mdtables.MemberRef.rows, LazyList)
 
+    # LazyList is initialized as a list of `None`.
+    # list.__getitem__ bypasses lazy loading.
     assert list.__getitem__(dn.net.mdtables.MemberRef.rows, 1) is None
     memref_row = dn.net.mdtables.MemberRef.rows[1]
     assert isinstance(memref_row, MemberRefRow)
+
     assert memref_row.Name
+    # __dict__ access bypasses lazy loading.
     assert "Signature" not in memref_row.__dict__
     assert memref_row.Signature
     assert "Signature" in memref_row.__dict__
 
+    # The first item of the rows list is a special case, because it is
+    # initialized without data before lazy-loading is setup.
+    # Make sure that it behaves the same as any other row when accessed.
     typeref_row = dn.net.mdtables.TypeRef.rows[0]
     assert isinstance(typeref_row, TypeRefRow)
+
     assert "ResolutionScope" not in typeref_row.__dict__
+    # TypeRefRow.Class should trigger a full load of all tables and rows.
     assert memref_row.Class
+    # This should not have been lazy-loaded, but will still have been loaded
+    # because of accessing the Class attribute.
     assert "ResolutionScope" in typeref_row.__dict__
 
+    # _resources is the underlying lazy-loaded field for the ClrResource list.
     assert dn.net._resources is None
     assert dn.net.resources is not None
     assert dn.net._resources is not None
@@ -48,12 +60,15 @@ def test_non_lazy_loading():
     assert dn.net.mdtables.MemberRef
     assert not isinstance(dn.net.mdtables.MemberRef.rows, LazyList)
 
+    # list.__getitem__ would bypass any lazy loading.
     memref_row = list.__getitem__(dn.net.mdtables.MemberRef.rows, 1)
     assert isinstance(memref_row, MemberRefRow)
+    # __dict__ access would bypass any lazy loading.
     assert "Signature" in memref_row.__dict__
 
     typeref_row = dn.net.mdtables.TypeRef.rows[0]
     assert isinstance(typeref_row, TypeRefRow)
     assert "ResolutionScope" in typeref_row.__dict__
 
+    # _resources is the underlying field that would be lazy-loaded.
     assert dn.net._resources is not None

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -32,7 +32,9 @@ def test_lazy_loading():
     # The first item of the rows list is a special case, because it is
     # initialized without data before lazy-loading is setup.
     # Make sure that it behaves the same as any other row when accessed.
-    typeref_row = dn.net.mdtables.TypeRef.rows[0]
+    # We can also verify that slicing works, since it too needs to be
+    # handled appropriately.
+    typeref_row = dn.net.mdtables.TypeRef.rows[:3:2][0]
     assert isinstance(typeref_row, TypeRefRow)
 
     assert "ResolutionScope" not in typeref_row.__dict__

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -1,0 +1,59 @@
+import fixtures
+
+import dnfile
+from dnfile.mdtable import TypeRefRow, MemberRefRow
+from dnfile.utils import LazyList
+
+
+def test_lazy_loading():
+    path = fixtures.get_data_path_by_name("hello-world.exe")
+
+    dn = dnfile.dnPE(path, clr_lazy_load=True)
+    dn.parse_data_directories()
+
+    assert dn.net
+    assert dn.net.mdtables
+
+    assert dn.net.mdtables.MemberRef
+    assert isinstance(dn.net.mdtables.MemberRef.rows, LazyList)
+
+    assert list.__getitem__(dn.net.mdtables.MemberRef.rows, 1) is None
+    memref_row = dn.net.mdtables.MemberRef.rows[1]
+    assert isinstance(memref_row, MemberRefRow)
+    assert memref_row.Name
+    assert "Signature" not in memref_row.__dict__
+    assert memref_row.Signature
+    assert "Signature" in memref_row.__dict__
+
+    typeref_row = dn.net.mdtables.TypeRef.rows[0]
+    assert isinstance(typeref_row, TypeRefRow)
+    assert "ResolutionScope" not in typeref_row.__dict__
+    assert memref_row.Class
+    assert "ResolutionScope" in typeref_row.__dict__
+
+    assert dn.net._resources is None
+    assert dn.net.resources is not None
+    assert dn.net._resources is not None
+
+
+def test_non_lazy_loading():
+    path = fixtures.get_data_path_by_name("hello-world.exe")
+
+    dn = dnfile.dnPE(path, clr_lazy_load=False)
+    dn.parse_data_directories()
+
+    assert dn.net
+    assert dn.net.mdtables
+
+    assert dn.net.mdtables.MemberRef
+    assert not isinstance(dn.net.mdtables.MemberRef.rows, LazyList)
+
+    memref_row = list.__getitem__(dn.net.mdtables.MemberRef.rows, 1)
+    assert isinstance(memref_row, MemberRefRow)
+    assert "Signature" in memref_row.__dict__
+
+    typeref_row = dn.net.mdtables.TypeRef.rows[0]
+    assert isinstance(typeref_row, TypeRefRow)
+    assert "ResolutionScope" in typeref_row.__dict__
+
+    assert dn.net._resources is not None

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -1,8 +1,8 @@
 import fixtures
 
 import dnfile
-from dnfile.mdtable import TypeRefRow, MemberRefRow
 from dnfile.utils import LazyList
+from dnfile.mdtable import TypeRefRow, MemberRefRow
 
 
 def test_lazy_loading():


### PR DESCRIPTION
Closes #73 

Some structure fields require all tables to be loaded in order to be fully initialized, so it may be a worth documenting these or allowing users to decide whether they're okay with these fields potentially being incomplete. 
ManifestRefRow.Implementation is one such field which is used when loading the assembly resources, so these are also parsed lazily.  

Timing loading the Celeste game executable to read the AssemblyReference names (my personal use-case) shows a very noticeable improvement with lazy loading enabled:
```
# before
time.perf_counter: 4.960689430000002 (+- ~0.5)
#after
time.perf_counter: 0.01197438199960743 (+- ~0.003)
```
```py
import dnfile, time

pe = dnfile.dnPE("Celeste.exe", fast_load=True, clr_lazy_load=True)

start = time.perf_counter()

pe.parse_data_directories()
asmrefs = pe.net.mdtables.AssemblyRef
asm_names = [asm.Name for asm in asmrefs]

end = time.perf_counter()
print("time.perf_counter: " + str(end-start))
```