### PR TITLE
Fix exception handling order in resource.py

### DIFF
--- a/src/dnfile/resource.py
+++ b/src/dnfile/resource.py
@@ -416,13 +416,13 @@ class ResourceSet(object):
             try:
                 e.struct.Name, size = self.read_serialized_data(offset)
                 e.name = e.struct.Name.decode("utf-16")
+            except UnicodeDecodeError:
+                # entry name is initialized to None, so just ignore
+                pass
             except ValueError:
                 # further entries may be ok; delay this exception
                 problems.append("CLR ResourceSet error: expected more data for entries at '{}' rsrc offset {}".format(self.parent.name, offset))
                 continue
-            except UnicodeDecodeError:
-                # entry name is initialized to None, so just ignore
-                pass
             offset += size
             e.struct.DataOffset = int.from_bytes(self._data[offset:offset + 4], byteorder="little")
             if self.struct.DataSectionOffset is None:


### PR DESCRIPTION
Note that `UnicodeDecodeError` is a subclass of `UnicodeError`, which is in turn a subclass of `ValueError`, so if `decode("utf-16")` fails it will throw `ValueError` before throwing `UnicodeDecodeError`.