### PR TITLE
Add NameStringsHeapIndex attribute to MethodDefRow

### DIFF
--- a/src/dnfile/base.py
+++ b/src/dnfile/base.py
@@ -164,6 +164,7 @@ class MDTableRow(abc.ABC):
     #  - indexes: resolve via given table name
     #  - lists: resolve many items via given table name
     #  - codedindexes: resolve via candidate list of tables
+    _struct_strings_heap_offsets: Dict[str, str]
     _struct_strings: Dict[str, str]
     _struct_guids: Dict[str, str]
     _struct_blobs: Dict[str, str]
@@ -293,6 +294,7 @@ class MDTableRow(abc.ABC):
             next_row    the next row in the table, used for row lists (e.g. FieldList, MethodList)
         """
         self._parse_struct_asis()
+        self._parse_struct_strings_heap_offsets()
         self._parse_struct_strings()
         self._parse_struct_guids()
         self._parse_struct_blobs()
@@ -309,6 +311,16 @@ class MDTableRow(abc.ABC):
             for struct_name, attr_name in self.__class__._struct_asis.items():
                 # always define attribute, even if failed to parse
                 setattr(self, attr_name, getattr(self.struct, struct_name, None))
+
+    def _parse_struct_strings_heap_offsets(self):
+        if hasattr(self.__class__, "_struct_strings_heap_offsets"):
+            for struct_name, attr_name in self.__class__._struct_strings_heap_offsets.items():
+                setattr(self, attr_name, None)
+                if self._strings is None:
+                    logger.warning("failed to fetch string: no strings table")
+                    continue
+                i = getattr(self.struct, struct_name, None)
+                setattr(self, attr_name, i)
 
     def _parse_struct_strings(self):
         # if strings

--- a/src/dnfile/mdtable.py
+++ b/src/dnfile/mdtable.py
@@ -344,6 +344,7 @@ class MethodDefRow(MDTableRow):
     ImplFlags: enums.ClrMethodImpl
     Flags: enums.ClrMethodAttr
     Name: str
+    NameStringsHeapIndex: int
     Signature: bytes
     ParamList: List[MDTableIndex["ParamRow"]]
 
@@ -355,6 +356,9 @@ class MethodDefRow(MDTableRow):
     _struct_flags = {
         "ImplFlags": ("ImplFlags", enums.ClrMethodImpl),
         "Flags": ("Flags", enums.ClrMethodAttr),
+    }
+    _struct_strings_heap_offsets = {
+        "Name_StringIndex": "NameStringsHeapIndex",
     }
     _struct_strings = {
         "Name_StringIndex": "Name",


### PR DESCRIPTION
This PR makes it possible to get the `#Strings` Heap Offset along with your method names, which has many applications, including patching of method names.

```python
import dnfile
pe = dnfile.dnPE('4a3b60496a793ee96a51fecf8690ef8312429a6b54d32f2a4424395c47b47fc8')
for method in pe.net.mdtables.MethodDef:
    print(f'{hex(method.NameStringsHeapIndex)}: {method.Name}')
```

Hopefully, I can add something to rename methods later :wink: 

Hope this helps.