### PR TITLE
Heap streams return objects instead of raw bytes or strings

### DIFF
--- a/src/dnfile/base.py
+++ b/src/dnfile/base.py
@@ -15,7 +15,8 @@ from typing import TYPE_CHECKING, Dict, List, Type, Tuple, Union, Generic, TypeV
 from pefile import Structure
 
 from . import enums, errors
-from .utils import LazyList as _LazyList, read_compressed_int as _read_compressed_int
+from .utils import LazyList as _LazyList
+from .utils import read_compressed_int as _read_compressed_int
 
 if TYPE_CHECKING:
     from . import stream
@@ -25,16 +26,16 @@ logger = logging.getLogger(__name__)
 
 
 class CompressedInt(int):
-    raw_size: Optional[int] = None
-    __data__: Optional[bytes] = None
-    value: Optional[int] = None
+    raw_size: int
+    __data__: bytes
+    value: int
     rva: Optional[int] = None
 
     def to_bytes(self):
         return self.__data__
 
     @classmethod
-    def read(cls, data: bytes, rva: Optional[int] = None) -> "CompressedInt":
+    def read(cls, data: bytes, rva: Optional[int] = None) -> Optional["CompressedInt"]:
         result = _read_compressed_int(data)
         if result is None:
             return None
@@ -119,7 +120,7 @@ class ClrStream(abc.ABC):
 class HeapItem(abc.ABC):
     rva: Optional[int] = None
     # original data from file
-    __data__: bytes = None
+    __data__: bytes
     # interpreted value
     value: Optional[bytes] = None
 

--- a/tests/test_invalid_streams.py
+++ b/tests/test_invalid_streams.py
@@ -9,7 +9,7 @@ def test_duplicate_stream():
     dn = dnfile.dnPE(path)
 
     assert b"#US" in dn.net.metadata.streams
-    assert dn.net.user_strings.get_us(1).value == "BBBBBBBB"
+    assert dn.net.user_strings.get(1).value == "BBBBBBBB"
 
 
 def test_unknown_stream():

--- a/tests/test_invalid_strings.py
+++ b/tests/test_invalid_strings.py
@@ -14,9 +14,11 @@ def test_unpaired_surrogate():
     assert dn.net.user_strings is not None
 
     assert b"#US" in dn.net.metadata.streams
-    assert dn.net.user_strings.get_bytes(1) == b"\xD0\xDD"
-    with pytest.raises(UnicodeDecodeError):
-        assert dn.net.user_strings.get(1)
+    item = dn.net.user_strings.get(1)
+    assert item is not None
+    assert item.flag == 0x01
+    assert item.value_bytes() == b"\xD0\xDD"
+    assert item.value is None
 
 
 def test_raw_binary():
@@ -30,12 +32,11 @@ def test_raw_binary():
 
     # short MZ header
     assert b"#US" in dn.net.metadata.streams
-    assert dn.net.user_strings.get_bytes(1) == b"\x4D\x5A\x90\x00"
-
-    # somehow this is valid utf-16
     s = dn.net.user_strings.get(1)
     assert s is not None
+    # somehow this is valid utf-16
     assert s.value == b"\x4D\x5A\x90\x00".decode("utf-16")
+    assert s.value_bytes() == b"\x4D\x5A\x90\x00"
 
 
 def test_string_decoder():
@@ -49,7 +50,11 @@ def test_string_decoder():
 
     # "Hello World" ^ 0xFF
     assert b"#US" in dn.net.metadata.streams
-    assert dn.net.user_strings.get_bytes(1) == b"\xb7\xff\x9a\xff\x93\xff\x93\xff\x90\xff\xdf\xff\xa8\xff\x90\xff\x8d\xff\x93\xff\x9b\xff"
+    item = dn.net.user_strings.get(1)
+    assert item is not None
+    assert item.raw_data == b"\x17\xb7\xff\x9a\xff\x93\xff\x93\xff\x90\xff\xdf\xff\xa8\xff\x90\xff\x8d\xff\x93\xff\x9b\xff\x01"
+    assert item.flag == 0x01
+    assert item.value_bytes() ==  b"\xb7\xff\x9a\xff\x93\xff\x93\xff\x90\xff\xdf\xff\xa8\xff\x90\xff\x8d\xff\x93\xff\x9b\xff"
 
     # somehow this is valid utf-16
     s = dn.net.user_strings.get(1)

--- a/tests/test_invalid_strings.py
+++ b/tests/test_invalid_strings.py
@@ -14,9 +14,9 @@ def test_unpaired_surrogate():
     assert dn.net.user_strings is not None
 
     assert b"#US" in dn.net.metadata.streams
-    assert dn.net.user_strings.get(1) == b"\xD0\xDD"
+    assert dn.net.user_strings.get_bytes(1) == b"\xD0\xDD"
     with pytest.raises(UnicodeDecodeError):
-        assert dn.net.user_strings.get_us(1)
+        assert dn.net.user_strings.get(1)
 
 
 def test_raw_binary():
@@ -30,10 +30,10 @@ def test_raw_binary():
 
     # short MZ header
     assert b"#US" in dn.net.metadata.streams
-    assert dn.net.user_strings.get(1) == b"\x4D\x5A\x90\x00"
+    assert dn.net.user_strings.get_bytes(1) == b"\x4D\x5A\x90\x00"
 
     # somehow this is valid utf-16
-    s = dn.net.user_strings.get_us(1)
+    s = dn.net.user_strings.get(1)
     assert s is not None
     assert s.value == b"\x4D\x5A\x90\x00".decode("utf-16")
 
@@ -49,8 +49,8 @@ def test_string_decoder():
 
     # "Hello World" ^ 0xFF
     assert b"#US" in dn.net.metadata.streams
-    assert dn.net.user_strings.get(1) == b"\xb7\xff\x9a\xff\x93\xff\x93\xff\x90\xff\xdf\xff\xa8\xff\x90\xff\x8d\xff\x93\xff\x9b\xff"
+    assert dn.net.user_strings.get_bytes(1) == b"\xb7\xff\x9a\xff\x93\xff\x93\xff\x90\xff\xdf\xff\xa8\xff\x90\xff\x8d\xff\x93\xff\x9b\xff"
 
     # somehow this is valid utf-16
-    s = dn.net.user_strings.get_us(1)
+    s = dn.net.user_strings.get(1)
     assert s is not None

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -297,7 +297,8 @@ def test_heap_items():
     # HeapItem
     buf = b"1234567890"
     item = dnfile.base.HeapItem(b"1234567890")
-    assert item.to_bytes() == b"1234567890"
+    assert item.raw_data == b"1234567890"
+    assert item.value_bytes() == buf
     assert item == b"1234567890"
     assert item.raw_size == len(b"1234567890")
     assert item.rva is None
@@ -310,36 +311,36 @@ def test_heap_items():
     buf = b"1234567890"
     buf_decoded = buf.decode("utf-8")
     str_item = dnfile.stream.HeapItemString(buf)
-    assert str_item.to_bytes() == buf
+    assert str_item.raw_data == buf
     assert str_item.encoding == "utf-8"
     assert str_item.value == buf_decoded
+    assert str_item.value_bytes() == buf
     assert str_item == buf_decoded
-    assert len(str_item) == len(buf_decoded)
-    assert str_item[5] == buf_decoded[5]
 
     # HeapItemBinary
     buf_with_compressed_int_len = b"\x0a1234567890"
     buf = b"1234567890"
     bin_item = dnfile.stream.HeapItemBinary(buf_with_compressed_int_len)
-    assert bin_item.to_bytes() == buf_with_compressed_int_len
+    assert bin_item.raw_data == buf_with_compressed_int_len
     assert bin_item.raw_size == len(buf_with_compressed_int_len)
     assert bin_item.item_size == len(buf)
+    assert bin_item.value_bytes() == buf
     assert bin_item == buf
 
     # UserString
     buf_with_flag = b"\x151\x002\x003\x004\x005\x006\x007\x008\x009\x000\x00\x00"
     us_str = "1234567890"
     us_item = dnfile.stream.UserString(buf_with_flag)
-    assert us_item.to_bytes() == buf_with_flag
+    assert us_item.raw_data == buf_with_flag
+    assert us_item.value_bytes() == buf_with_flag[1:-1]
     assert us_item.value == us_str
     assert us_item == us_str
-    assert len(us_item) == len(us_str)
-    assert us_item[5] == us_str[5]
 
     # GUID
     guid_bytes = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"
     guid_item = dnfile.stream.HeapItemGuid(guid_bytes)
     assert guid_item is not None
-    assert guid_item.to_bytes() == guid_bytes
+    assert guid_item.raw_data == guid_bytes
+    assert guid_item.value_bytes() == guid_bytes
     assert guid_item.value == guid_bytes
     assert str(guid_item) == "03020100-0504-0706-0809-0a0b0c0d0e0f"

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -64,6 +64,7 @@ def test_guids():
     assert dn.net.guids.get(0) is None
     assert dn.net.guids.get(1).value == b"\x8c\x8b\xc5\x48\xff\x24\x91\x45\x9e\xc8\x94\xbf\xea\xbd\x9f\x3e"
 
+
 def test_tables():
     path = fixtures.get_data_path_by_name("hello-world.exe")
 
@@ -313,6 +314,8 @@ def test_heap_items():
     assert str_item.encoding == "utf-8"
     assert str_item.value == buf_decoded
     assert str_item == buf_decoded
+    assert len(str_item) == len(buf_decoded)
+    assert str_item[5] == buf_decoded[5]
 
     # HeapItemBinary
     buf_with_compressed_int_len = b"\x0a1234567890"
@@ -324,10 +327,14 @@ def test_heap_items():
     assert bin_item == buf
 
     # UserString
-    buf_with_flag = b"\x0b1234567890\x00"
-    buf = b"1234567890"
+    buf_with_flag = b"\x151\x002\x003\x004\x005\x006\x007\x008\x009\x000\x00\x00"
+    us_str = "1234567890"
     us_item = dnfile.stream.UserString(buf_with_flag)
     assert us_item.to_bytes() == buf_with_flag
+    assert us_item.value == us_str
+    assert us_item == us_str
+    assert len(us_item) == len(us_str)
+    assert us_item[5] == us_str[5]
 
     # GUID
     guid_bytes = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"


### PR DESCRIPTION
This adds support for easily identifying the RVA of any heap item, including Strings, Guids, and UserStrings.  It does so by creating HeapItem classes that contain the raw bytes, the decoded values, and the rva where the raw bytes were found in the underlying PE.

The .get() member of each of these heap streams now returns these objects. This is a potential **BREAKING CHANGE**, however the HeapItem subclasses can be treated similarly to what they represent.  The original .get() functions have been renamed to .get_bytes() or .get_str() where before they returned bytes or str.

HeapItemString and UserString can be indexed like and compared to strings.  HeapItemBinary can be indexed like and compared to bytes objects.

Closes #85 