### PR TITLE
fix: typehint Version field in ClrMetaDataStruct as bytes

### DIFF
--- a/src/dnfile/__init__.py
+++ b/src/dnfile/__init__.py
@@ -230,7 +230,7 @@ class ClrMetaDataStruct(Structure):
     MinorVersion: int
     Reserved: int
     VersionLength: int
-    Version: int
+    Version: bytes
     Flags: int
     NumberOfStreams: int
 


### PR DESCRIPTION
Fixed typehint.

https://github.com/malwarefrank/dnfile/blob/b7dd509f56edb99b36c71e468bddbc92a8c5bcda/src/dnfile/__init__.py#L232-L233
https://github.com/malwarefrank/dnfile/blob/b7dd509f56edb99b36c71e468bddbc92a8c5bcda/src/dnfile/__init__.py#L311-L314